### PR TITLE
Defer date to start of day

### DIFF
--- a/app/helpers/defer-date.js
+++ b/app/helpers/defer-date.js
@@ -1,5 +1,6 @@
 import { helper } from '@ember/component/helper';
 import addDays from 'date-fns/addDays';
+import startOfDay from 'date-fns/startOfDay';
 
 export function deferDateFn({ start, days, now = new Date() }) {
   let startToUse;
@@ -11,7 +12,7 @@ export function deferDateFn({ start, days, now = new Date() }) {
     startToUse = start;
   }
 
-  return addDays(startToUse, days);
+  return startOfDay(addDays(startToUse, days));
 }
 
 export default helper(function deferDate(_, { start, days }) {

--- a/tests/unit/helpers/defer-date-test.js
+++ b/tests/unit/helpers/defer-date-test.js
@@ -1,4 +1,5 @@
 import addDays from 'date-fns/addDays';
+import startOfDay from 'date-fns/startOfDay';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import { deferDateFn } from 'surely/helpers/defer-date';
@@ -7,10 +8,10 @@ module('Unit | Helper | defer-date', function (hooks) {
   setupTest(hooks);
 
   const now = new Date();
-  const yesterday = addDays(now, -1);
-  const tomorrow = addDays(now, 1);
-  const twoDaysFromNow = addDays(now, 2);
-  const threeDaysFromNow = addDays(now, 3);
+  const yesterday = startOfDay(addDays(now, -1));
+  const tomorrow = startOfDay(addDays(now, 1));
+  const twoDaysFromNow = startOfDay(addDays(now, 2));
+  const threeDaysFromNow = startOfDay(addDays(now, 3));
 
   test('it can get the next day', function (assert) {
     let result = deferDateFn({


### PR DESCRIPTION
#110 changed how deferredUntil dates were calculated so they were no longer the start of the day. This broke functionality for what day for items to show on, and how they are grouped.