### PR TITLE
Update Ember Data to 3.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",
-    "ember-data": "~3.21.0",
+    "ember-data": "~3.22.1",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,45 +1138,45 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-data/adapter@3.21.2":
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.21.2.tgz#effa7c7036739cc5ee5506c23cb41dd31855333b"
-  integrity sha512-bqc+HaYEdwX4HYm9a0GE8hZ8sc51z35qLsRb97ziwFpA6hDXhZqMg6kdPymmUD6BBnN80Og7vH+OR6MdPkQDzA==
+"@ember-data/adapter@3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/adapter/-/adapter-3.22.1.tgz#dd286db0b7ef8114552957e71eaf6c1452bd16cf"
+  integrity sha512-Do9Ibga0SyuPBTvuMz9fzhO1gHIQPzlhCkvOu6k1RWLEWYkzz00Wpf2nJ8aNyxfA6rO9JeL7iq6ms45fEpPOUg==
   dependencies:
-    "@ember-data/private-build-infra" "3.21.2"
-    "@ember-data/store" "3.21.2"
+    "@ember-data/private-build-infra" "3.22.1"
+    "@ember-data/store" "3.22.1"
     "@ember/edition-utils" "^1.2.0"
     ember-cli-babel "^7.18.0"
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^3.1.3"
 
-"@ember-data/canary-features@3.21.2":
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.21.2.tgz#9cb05922cc8f1fdd236c6d336e3de62de2541085"
-  integrity sha512-7iRqPGt4ccNquJ+oDEM66v3v/gLSdi0dKgej1YaG7iRqtsHS2ShojuQsAilZh4Rtmy/vv7bZFZjiBDz4bTf48A==
+"@ember-data/canary-features@3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/canary-features/-/canary-features-3.22.1.tgz#304ff7d54793caf396e6179b59602407d6fb3df5"
+  integrity sha512-DsYeDOlA5eIdj86Vc+OoEl6U3+BrE6mtmvJ5uW2G+KD+2aPgL51q0scomcCo2tlNoVAS6/j998yx9Auz9qvieg==
   dependencies:
     ember-cli-babel "^7.18.0"
     ember-cli-typescript "^3.1.3"
 
-"@ember-data/debug@3.21.2":
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.21.2.tgz#b0370df4e85acf74a7bfe8d86e39c2c90ff56380"
-  integrity sha512-T17yTfrqLhP7ayzX8mat7yA4tFsxCW3k1E8nxuKFWsVfhMPUOKvnaS743VmJdWXmHdm4SuxD17t2ajGPAmz1Vw==
+"@ember-data/debug@3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.22.1.tgz#7ccf0989939fd7fbfe36b033455a581c774ac488"
+  integrity sha512-kMMeN7IiWLLXLfadfsfrmPxB40PcadahKpLK3HpXaFCYTSGvyvRaBnPJfABsclemjJRdi0XNwCWm/QZAHQ7KJw==
   dependencies:
-    "@ember-data/private-build-infra" "3.21.2"
+    "@ember-data/private-build-infra" "3.22.1"
     "@ember/edition-utils" "^1.2.0"
     ember-cli-babel "^7.18.0"
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^3.1.3"
 
-"@ember-data/model@3.21.2":
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.21.2.tgz#ebcbaee9bcb75489ef4be7687a17d266fb908aa2"
-  integrity sha512-+Z4inXkeNbz7tKI4EaiurN35yTJ/B6KTRIZyjx/cpULooJ9pyAYLsVHDYYqxw622izDQ9JWSftqJl8vhva5F3A==
+"@ember-data/model@3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.22.1.tgz#16ee9da04ecd398a319fd0ab76fa1759fdd562b7"
+  integrity sha512-1zOgPGb6lWDozXfQJzbz5KkMDZLazdmXpy8Wr32lYrqgKZ8A80T5Wy6ywtTbuI35A+Q1vxsJlAGZm3R4ucQB+Q==
   dependencies:
-    "@ember-data/canary-features" "3.21.2"
-    "@ember-data/private-build-infra" "3.21.2"
-    "@ember-data/store" "3.21.2"
+    "@ember-data/canary-features" "3.22.1"
+    "@ember-data/private-build-infra" "3.22.1"
+    "@ember-data/store" "3.22.1"
     "@ember/edition-utils" "^1.2.0"
     ember-cli-babel "^7.18.0"
     ember-cli-string-utils "^1.1.0"
@@ -1185,13 +1185,13 @@
     ember-compatibility-helpers "^1.2.0"
     inflection "1.12.0"
 
-"@ember-data/private-build-infra@3.21.2":
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.21.2.tgz#9ba22e5c3624462a5397c45728e1cfadf1f1da5b"
-  integrity sha512-eg2M0IJYghdkNwnf9J/SF23pCh/hjun0dG9AfPJWUGpvJM4DlEAjex1Zh+JB71e7CVxx2a9yLsPuHe86R89jJg==
+"@ember-data/private-build-infra@3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/private-build-infra/-/private-build-infra-3.22.1.tgz#db7c61c9c2e84de3abd6a0ad56a5497be126248b"
+  integrity sha512-TwUkveE4WnD6ZWRzXBBqUdm/pj5CT3OmmHEuMelIavW1VVtGwJKhP5rCoVO0j3y9uYUeqsWbZechcQeqboFSrQ==
   dependencies:
     "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@ember-data/canary-features" "3.21.2"
+    "@ember-data/canary-features" "3.22.1"
     "@ember/edition-utils" "^1.2.0"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
@@ -1217,14 +1217,14 @@
     semver "^7.1.3"
     silent-error "^1.1.1"
 
-"@ember-data/record-data@3.21.2":
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.21.2.tgz#0e7b53451f70aa20f48fbc046786999633d278a4"
-  integrity sha512-MJKvsHNIrHVJze3iQdlHfsCGRwrm4WbI6qlh9ecTOMhrhjLQufJCW+Ea2mLNg8pB9rNhhL4tqTNUByNc6DtmGw==
+"@ember-data/record-data@3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/record-data/-/record-data-3.22.1.tgz#71ee2200b9c6913e7643d224e8962affc8d554f8"
+  integrity sha512-lZ/ismPvWvBYi26Dselqbfep4Ii+YxoS+iAK8DQ3LJY27atLsqsUxMXysZjqaK4OZT7hYuPIkK1p7Q5nP/uLCw==
   dependencies:
-    "@ember-data/canary-features" "3.21.2"
-    "@ember-data/private-build-infra" "3.21.2"
-    "@ember-data/store" "3.21.2"
+    "@ember-data/canary-features" "3.22.1"
+    "@ember-data/private-build-infra" "3.22.1"
+    "@ember-data/store" "3.22.1"
     "@ember/edition-utils" "^1.2.0"
     "@ember/ordered-set" "^2.0.3"
     ember-cli-babel "^7.18.0"
@@ -1236,24 +1236,24 @@
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@ember-data/serializer@3.21.2":
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.21.2.tgz#0c893dc57f6d4c965e5f40f30a40b7b6b36a7558"
-  integrity sha512-rjdLMNg8j+pNpTgNT0SIFM6mLYYWeMEMt7sIU1Cz7sRi/Wg37lomo3WJ2V3BoS/TEXKqzv30Ibjr7tfIJgCsUg==
+"@ember-data/serializer@3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/serializer/-/serializer-3.22.1.tgz#26083c93e5cc283da43d379779e6eec89f61189a"
+  integrity sha512-qs6+IZJrVMviTWS6MvhgwrZ14DMfk8XGZkzh/ZuCfSAPqvZe9gGdNH6VZ2pO0U8f8uxyVQRPQ5XFTJ/kQ+/N5g==
   dependencies:
-    "@ember-data/private-build-infra" "3.21.2"
-    "@ember-data/store" "3.21.2"
+    "@ember-data/private-build-infra" "3.22.1"
+    "@ember-data/store" "3.22.1"
     ember-cli-babel "^7.18.0"
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^3.1.3"
 
-"@ember-data/store@3.21.2":
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.21.2.tgz#fe3139a33059a872cf3036d08a8a334ec30c414e"
-  integrity sha512-aA9SogU8OZsKSoKuh7qgvSqSM9uAdumGWhaPQEgXhIp5EKB5TVK4COHUSG9AWY/4DMOq95xEsu/4+d03jnakBg==
+"@ember-data/store@3.22.1":
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.22.1.tgz#373b13d25fbdbb8fc940575aa66141b07f184c96"
+  integrity sha512-2Iy7sB8JhKN4l4D3GOD2+31rZ8buVNwGodZD++uldisYlaLNdlhK6povhxuDSxu3j+g3bH8qXpFqTezE11EyjA==
   dependencies:
-    "@ember-data/canary-features" "3.21.2"
-    "@ember-data/private-build-infra" "3.21.2"
+    "@ember-data/canary-features" "3.22.1"
+    "@ember-data/private-build-infra" "3.22.1"
     ember-cli-babel "^7.18.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-typescript "^3.1.3"
@@ -6261,18 +6261,18 @@ ember-css-transitions@^0.1.16:
     ember-cli-babel "^6.16.0"
     ember-cli-requestanimationframe-polyfill "^0.0.1"
 
-ember-data@~3.21.0:
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.21.2.tgz#d3537319a8d1c80a8a567f08d86b740722d502fe"
-  integrity sha512-Z+DCWczMBC04ahANj+AqOwXeXrqPmtwaJ+2SnomM9s8PaUcILVZPToTudUBU2rdnS2MjkpmcUVIIYiXEvAetgg==
+ember-data@~3.22.1:
+  version "3.22.1"
+  resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.22.1.tgz#5b075fc8a2c3f18dac2305037d34b88666631b1a"
+  integrity sha512-5QXJkkwSXKgdVa9qg6lYrTdG7+5PvtfwLwj0weCOFixXLxZWyhXzPcnDyn4lNDCyMZbsy/10VNH5miPkRBf8lQ==
   dependencies:
-    "@ember-data/adapter" "3.21.2"
-    "@ember-data/debug" "3.21.2"
-    "@ember-data/model" "3.21.2"
-    "@ember-data/private-build-infra" "3.21.2"
-    "@ember-data/record-data" "3.21.2"
-    "@ember-data/serializer" "3.21.2"
-    "@ember-data/store" "3.21.2"
+    "@ember-data/adapter" "3.22.1"
+    "@ember-data/debug" "3.22.1"
+    "@ember-data/model" "3.22.1"
+    "@ember-data/private-build-infra" "3.22.1"
+    "@ember-data/record-data" "3.22.1"
+    "@ember-data/serializer" "3.22.1"
+    "@ember-data/store" "3.22.1"
     "@ember/edition-utils" "^1.2.0"
     "@ember/ordered-set" "^2.0.3"
     "@glimmer/env" "^0.1.7"


### PR DESCRIPTION
Not updating Ember Source or CLI yet because of an error that Ember Source 3.22 triggers with Ember Paper.

Likely at this point to switch off of Ember Paper.