### PR TITLE
Add truth helpers as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "ember-source": "~3.21.1",
     "ember-template-lint": "^2.14.0",
     "ember-test-selectors": "^5.0.0",
+    "ember-truth-helpers": "^3.0.0",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-ember": "^9.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6636,6 +6636,13 @@ ember-truth-helpers@2.1.0, ember-truth-helpers@^2.1.0:
   dependencies:
     ember-cli-babel "^6.6.0"
 
+ember-truth-helpers@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-3.0.0.tgz#86766bdca4ac9b86bce3d262dff2aabc4a0ea384"
+  integrity sha512-hPKG9QqruAELh0li5xaiLZtr88ioWYxWCXisAWHWE0qCP4a2hgtuMzKUPpiTCkltvKjuqpzTZCU4VhQ+IlRmew==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+
 emittery@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"


### PR DESCRIPTION
Used directly in app code, but was transitive dependency of Ember-Paper. Importing it directly to express the dependency, and to prepare to remove Ember-Paper.